### PR TITLE
Fix readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ build:
   tools:
     python: "3.12"
 sphinx:
-  configuration: documentation/source/conf.py
+  configuration: docs/source/conf.py
 python:
   install:
     - method: pip


### PR DESCRIPTION
Path for the sphinx config file as defined for ReadTheDocs has been fixed