### PR TITLE
Fix automatic versioning based on tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ Issues        = "https://github.com/HiDiHlabs/ovrl.py/issues"
 [tool.setuptools]
 packages = ["ovrlpy"]
 
+[tool.setuptools_scm]
+
 [tool.ruff]
 target-version = "py311"
 


### PR DESCRIPTION
With this inclusion in the pyproject.toml automatic versioning should work now